### PR TITLE
feat: change theme

### DIFF
--- a/lib/feature/pokemon_list/pokemon_list_connector.dart
+++ b/lib/feature/pokemon_list/pokemon_list_connector.dart
@@ -1,0 +1,22 @@
+import 'package:async_redux/async_redux.dart';
+import 'package:flutter/material.dart';
+import 'package:pokedex_flutter_async_redux/feature/pokemon_list/pokemon_list_page.dart';
+import 'package:pokedex_flutter_async_redux/feature/pokemon_list/pokemon_list_vm.dart';
+import 'package:pokedex_flutter_async_redux/state/app_state.dart';
+
+class PokemonListConnector extends StatelessWidget {
+  const PokemonListConnector({super.key});
+
+  static const route = '/';
+
+  @override
+  Widget build(BuildContext context) {
+    return StoreConnector<AppState, PokemonListVm>(
+      vm: PokemonListVmFactory.new,
+      builder: (_, vm) => PokemonListPage(
+        savedThemeMode: vm.savedThemeMode,
+        onSetTheme: vm.onSetTheme,
+      ),
+    );
+  }
+}

--- a/lib/feature/pokemon_list/pokemon_list_page.dart
+++ b/lib/feature/pokemon_list/pokemon_list_page.dart
@@ -1,12 +1,18 @@
+import 'package:dartx/dartx.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:pokedex_flutter_async_redux/utils/extension.dart';
 import 'package:pokedex_flutter_async_redux/utils/strings.dart';
 
 class PokemonListPage extends StatelessWidget {
-  const PokemonListPage({super.key});
+  const PokemonListPage({
+    required this.savedThemeMode,
+    required this.onSetTheme,
+    super.key,
+  });
 
-  static const route = '/';
+  final ThemeMode savedThemeMode;
+  final ValueChanged<ThemeMode> onSetTheme;
 
   void _showThemeChoiceDialog(BuildContext context) => showDialog<void>(
         context: context,
@@ -14,15 +20,13 @@ class PokemonListPage extends StatelessWidget {
           title: const Text(chooseThemeMenuLabel),
           content: Column(
             mainAxisSize: MainAxisSize.min,
-            children: themeOptionLabels.map(
-              (themeOption) {
+            children: ThemeMode.values.map(
+              (themeMode) {
                 return RadioListTile(
-                  title: Text(themeOption),
-                  value: ThemeMode.light,
-                  // TODO: Update value
-                  groupValue: ThemeMode.light,
-                  // TODO: Update function
-                  onChanged: (_) => context.pop(),
+                  title: Text(themeMode.name.capitalize()),
+                  value: themeMode,
+                  groupValue: savedThemeMode,
+                  onChanged: (value) => _onSelectTheme(context, value),
                 );
               },
             ).toList(),
@@ -32,6 +36,11 @@ class PokemonListPage extends StatelessWidget {
 
   void _onSelectOption(BuildContext context, String option) {
     if (option == chooseThemeMenuLabel) _showThemeChoiceDialog(context);
+  }
+
+  void _onSelectTheme(BuildContext context, ThemeMode? themeMode) {
+    onSetTheme(themeMode ?? ThemeMode.system);
+    context.pop();
   }
 
   @override

--- a/lib/feature/pokemon_list/pokemon_list_vm.dart
+++ b/lib/feature/pokemon_list/pokemon_list_vm.dart
@@ -1,0 +1,25 @@
+import 'package:async_redux/async_redux.dart';
+import 'package:flutter/material.dart';
+import 'package:pokedex_flutter_async_redux/feature/pokemon_list/pokemon_list_connector.dart';
+import 'package:pokedex_flutter_async_redux/state/action/actions.dart';
+import 'package:pokedex_flutter_async_redux/state/app_state.dart';
+
+class PokemonListVmFactory extends VmFactory<AppState, PokemonListConnector, PokemonListVm> {
+  @override
+  PokemonListVm fromStore() => PokemonListVm(
+        savedThemeMode: state.savedThemeMode,
+        onSetTheme: _onSetTheme,
+      );
+
+  void _onSetTheme(ThemeMode themeMode) => dispatch(SetThemeAction(themeMode));
+}
+
+class PokemonListVm extends Vm {
+  final ThemeMode savedThemeMode;
+  final ValueChanged<ThemeMode> onSetTheme;
+
+  PokemonListVm({
+    required this.savedThemeMode,
+    required this.onSetTheme,
+  }) : super(equals: [savedThemeMode]);
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,13 +1,22 @@
 import 'package:async_redux/async_redux.dart';
 import 'package:flutter/material.dart';
 import 'package:pokedex_flutter_async_redux/pokedex_app.dart';
+import 'package:pokedex_flutter_async_redux/state/action/actions.dart';
 import 'package:pokedex_flutter_async_redux/state/app_state.dart';
+import 'package:pokedex_flutter_async_redux/utils/strings.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
-void main() {
+void main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
   final state = AppState();
   final store = Store<AppState>(initialState: state);
+
+  final prefs = await SharedPreferences.getInstance();
+  final savedThemeIndex = prefs.getInt(themeSharedPrefsKey) ?? ThemeMode.system.index;
+  final savedTheme = ThemeMode.values[savedThemeIndex];
+
+  await store.dispatchAndWait(SetThemeAction(savedTheme));
 
   runApp(
     StoreProvider<AppState>(

--- a/lib/state/action/actions.dart
+++ b/lib/state/action/actions.dart
@@ -1,0 +1,25 @@
+import 'package:async_redux/async_redux.dart';
+import 'package:flutter/material.dart';
+import 'package:pokedex_flutter_async_redux/state/app_state.dart';
+import 'package:pokedex_flutter_async_redux/utils/strings.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Change the state's theme with the selected [themeMode]
+/// Additionally save the selected [themeMode] to shared prefs
+/// Don't dispatch if state's saved theme is the same as the selected
+class SetThemeAction extends ReduxAction<AppState> {
+  SetThemeAction(this.themeMode);
+
+  final ThemeMode themeMode;
+
+  @override
+  bool abortDispatch() => state.savedThemeMode == themeMode;
+
+  @override
+  Future<AppState> reduce() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt(themeSharedPrefsKey, themeMode.index);
+
+    return state.copyWith(savedThemeMode: themeMode);
+  }
+}

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -6,6 +6,6 @@ part 'app_state.freezed.dart';
 @freezed
 class AppState with _$AppState {
   factory AppState({
-    @Default(ThemeMode.system) ThemeMode themeMode,
+    @Default(ThemeMode.system) ThemeMode savedThemeMode,
   }) = _AppState;
 }

--- a/lib/utils/router.dart
+++ b/lib/utils/router.dart
@@ -1,20 +1,20 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
-import 'package:pokedex_flutter_async_redux/feature/pokemon_list/pokemon_list_page.dart';
+import 'package:pokedex_flutter_async_redux/feature/pokemon_list/pokemon_list_connector.dart';
 
 final navigatorKey = GlobalKey<NavigatorState>();
 
 final router = GoRouter(
   routes: [
     GoRoute(
-      path: PokemonListPage.route,
-      builder: (_, __) => const PokemonListPage(),
+      path: PokemonListConnector.route,
+      builder: (_, __) => const PokemonListConnector(),
     ),
   ],
-  initialLocation: PokemonListPage.route,
+  initialLocation: PokemonListConnector.route,
   debugLogDiagnostics: kDebugMode,
-  errorBuilder: (_, __) => const PokemonListPage(),
+  errorBuilder: (_, __) => const PokemonListConnector(),
   observers: [routeObserver],
   navigatorKey: navigatorKey,
 );

--- a/lib/utils/strings.dart
+++ b/lib/utils/strings.dart
@@ -1,3 +1,3 @@
 const appTitle = 'Pokedex';
 const chooseThemeMenuLabel = 'Choose Theme';
-const themeOptionLabels = ['Light', 'Dark', 'System'];
+const themeSharedPrefsKey = 'theme';

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -214,6 +214,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.7"
+  dartx:
+    dependency: "direct main"
+    description:
+      name: dartx
+      sha256: "8b25435617027257d43e6508b5fe061012880ddfdaa75a71d607c3de2a13d244"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.0"
   dbus:
     dependency: transitive
     description:
@@ -581,6 +589,62 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
+  shared_preferences:
+    dependency: "direct main"
+    description:
+      name: shared_preferences
+      sha256: "746e5369a43170c25816cc472ee016d3a66bc13fcf430c0bc41ad7b4b2922051"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
+  shared_preferences_android:
+    dependency: transitive
+    description:
+      name: shared_preferences_android
+      sha256: "3b9febd815c9ca29c9e3520d50ec32f49157711e143b7a4ca039eb87e8ade5ab"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.3"
+  shared_preferences_foundation:
+    dependency: transitive
+    description:
+      name: shared_preferences_foundation
+      sha256: "07e050c7cd39bad516f8d64c455f04508d09df104be326d8c02551590a0d513d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.3"
+  shared_preferences_linux:
+    dependency: transitive
+    description:
+      name: shared_preferences_linux
+      sha256: "580abfd40f415611503cae30adf626e6656dfb2f0cee8f465ece7b6defb40f2f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_platform_interface:
+    dependency: transitive
+    description:
+      name: shared_preferences_platform_interface
+      sha256: "57cbf196c486bc2cf1f02b85784932c6094376284b3ad5779d1b1c6c6a816b80"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_web:
+    dependency: transitive
+    description:
+      name: shared_preferences_web
+      sha256: d2ca4132d3946fec2184261726b355836a82c33d7d5b67af32692aff18a4684e
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.2"
+  shared_preferences_windows:
+    dependency: transitive
+    description:
+      name: shared_preferences_windows
+      sha256: "94ef0f72b2d71bc3e700e025db3710911bd51a71cefb65cc609dd0d9a982e3c1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
   shelf:
     dependency: transitive
     description:
@@ -674,6 +738,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.2"
+  time:
+    dependency: transitive
+    description:
+      name: time
+      sha256: ad8e018a6c9db36cb917a031853a1aae49467a93e0d464683e029537d848c221
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.4"
   timing:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,9 +11,11 @@ dependencies:
     sdk: flutter
   async_redux: ^23.2.0
   cupertino_icons: ^1.0.8
+  dartx: ^1.2.0
   freezed: ^2.5.7
   freezed_annotation: ^2.4.4
   go_router: ^14.3.0
+  shared_preferences: ^2.3.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
- add dartx and shared preferences packages
- remove unnecessary theme option labels and use theme mode values
- add theme shared prefs key string
- create actin for setting theme
- add vm and connector for pokemon list
- add saved theme mode and on set theme properties in pokemon list page
- add on select theme functiion in pokemon list page
- get saved theme in main
- use pokemon list connector instead of page in router