### PR TITLE
feat: get more pokemon

### DIFF
--- a/lib/apis/pokemon_api.dart
+++ b/lib/apis/pokemon_api.dart
@@ -12,9 +12,9 @@ class PokemonApi {
 
   PokemonApi(this.apiClient);
 
-  Future<SimplePokemonListDto> getSimplePokemonList() async {
-    final baseUrl = apiClient.baseUrl;
-    final response = await apiClient.dio.get<Json>('$baseUrl/pokemon');
+  Future<SimplePokemonListDto> getSimplePokemonList({String? nextPageUrl}) async {
+    final fetchUrl = nextPageUrl ?? '${apiClient.baseUrl}/pokemon';
+    final response = await apiClient.dio.get<Json>(fetchUrl);
     final simplePokemonList = SimplePokemonList.fromJson(response.data!);
 
     return simplePokemonList.toDto();

--- a/lib/feature/pokemon_list/pokemon_list_connector.dart
+++ b/lib/feature/pokemon_list/pokemon_list_connector.dart
@@ -19,6 +19,9 @@ class PokemonListConnector extends StatelessWidget {
         savedThemeMode: vm.savedThemeMode,
         onSetTheme: vm.onSetTheme,
         unionPageState: vm.unionPageState,
+        onGetMorePokemon: vm.onGetMorePokemon,
+        isGettingMorePokemon: vm.isGettingMorePokemon,
+        onRefreshPage: vm.onRefreshPage,
       ),
     );
   }

--- a/lib/feature/pokemon_list/pokemon_list_vm.dart
+++ b/lib/feature/pokemon_list/pokemon_list_vm.dart
@@ -1,4 +1,5 @@
 import 'package:async_redux/async_redux.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:pokedex_flutter_async_redux/feature/pokemon_list/pokemon_list_connector.dart';
 import 'package:pokedex_flutter_async_redux/model/union_page_state.dart';
@@ -14,6 +15,9 @@ class PokemonListVmFactory extends VmFactory<AppState, PokemonListConnector, Pok
         savedThemeMode: state.savedThemeMode,
         onSetTheme: _onSetTheme,
         unionPageState: _getLoadingState(),
+        onGetMorePokemon: _onGetMorePokemon,
+        isGettingMorePokemon: state.wait.isWaiting(GetMorePokemonAction.waitKey),
+        onRefreshPage: _onRefreshPage,
       );
 
   void _onSetTheme(ThemeMode themeMode) => dispatch(SetThemeAction(themeMode));
@@ -23,21 +27,32 @@ class PokemonListVmFactory extends VmFactory<AppState, PokemonListConnector, Pok
     if (state.pokemonList.isEmpty) return const UnionPageState.error(emptyPokemonLabel);
     return UnionPageState(state.pokemonList);
   }
+
+  void _onGetMorePokemon() => dispatch(GetMorePokemonAction());
+
+  Future<void> _onRefreshPage() async => dispatch(InitPokemonListPageAction());
 }
 
 class PokemonListVm extends Vm {
   final ThemeMode savedThemeMode;
   final ValueChanged<ThemeMode> onSetTheme;
   final UnionPageState<PokemonList> unionPageState;
+  final VoidCallback onGetMorePokemon;
+  final bool isGettingMorePokemon;
+  final AsyncCallback onRefreshPage;
 
   PokemonListVm({
     required this.savedThemeMode,
     required this.onSetTheme,
     required this.unionPageState,
+    required this.onGetMorePokemon,
+    required this.isGettingMorePokemon,
+    required this.onRefreshPage,
   }) : super(
           equals: [
             savedThemeMode,
             unionPageState,
+            isGettingMorePokemon,
           ],
         );
 }

--- a/lib/utils/const.dart
+++ b/lib/utils/const.dart
@@ -8,3 +8,5 @@ const pokemonNamePadding = EdgeInsets.symmetric(vertical: 8.0);
 const pokemonListPageFooterHeight = 100.0;
 const pokemonGridDelegate = SliverGridDelegateWithMaxCrossAxisExtent(maxCrossAxisExtent: 250, childAspectRatio: 3 / 2);
 const pokemonListPagePadding = EdgeInsets.symmetric(horizontal: 12.0);
+const morePokemonCount = 20;
+const progressIndicatorFooterPadding = EdgeInsets.all(12.0);


### PR DESCRIPTION
- create action for getting more pokemon
- add next page url property in get simple pokemon list action
- add consts
- clear pokemon list in get simple pokemon list action if refreshing
- remove unnecessary adding to simple pokemon list in get simple pokemon list action
- add on get more pokemon, is getting more pokemon, and on refresh page properties in pokemon list page and vm
- change pokemon list page to stateful
- add scroll controller variable in pokemon list page
- add on reach end function in pokemon list page
- wrap body of pokemon list page with refresh indicator
- add loading indicator on footer in pokemon list page if getting more pokemon
- add next page url parameter in get simple pokemon list method in pokemon api