### PR TITLE
fix: search refresh

### DIFF
--- a/lib/feature/pokemon_list/pokemon_list_page.dart
+++ b/lib/feature/pokemon_list/pokemon_list_page.dart
@@ -95,7 +95,7 @@ class _PokemonListPageState extends State<PokemonListPage> {
 
   void _onPressSearch() {
     _isSearchingNotifier.value = !_isSearchingNotifier.value;
-    if (_textEditingController.text.isNotEmpty) _textEditingController.clear();
+    _onClearText();
   }
 
   void _onUpdateText() {
@@ -104,6 +104,16 @@ class _PokemonListPageState extends State<PokemonListPage> {
       debouncerDelayInMilliseconds.milliseconds,
       () => widget.onSearchPokemon(_textEditingController.text),
     );
+  }
+
+  Future<void> _onRefresh() async {
+    _onClearText();
+    if (_isSearchingNotifier.value) _isSearchingNotifier.value = false;
+    widget.onRefreshPage();
+  }
+
+  void _onClearText() {
+    if (_textEditingController.text.isNotEmpty) _textEditingController.clear();
   }
 
   @override
@@ -136,7 +146,7 @@ class _PokemonListPageState extends State<PokemonListPage> {
             ),
           ),
           IconButton(
-            onPressed: widget.onRefreshPage,
+            onPressed: _onRefresh,
             icon: const Icon(Icons.refresh),
           ),
           PopupMenuButton(
@@ -153,7 +163,7 @@ class _PokemonListPageState extends State<PokemonListPage> {
         ],
       ),
       body: RefreshIndicator(
-        onRefresh: widget.onRefreshPage,
+        onRefresh: _onRefresh,
         child: Padding(
           padding: pokemonListPagePadding,
           child: (_textEditingController.text.isNotEmpty ? widget.unionSearchPageState : widget.unionPageState).when(

--- a/lib/state/action/pokemon_actions.dart
+++ b/lib/state/action/pokemon_actions.dart
@@ -6,6 +6,7 @@ import 'package:pokedex_flutter_async_redux/state/app_state.dart';
 
 /// Gets the pokemon list at the start to display
 /// Gets the simple pokemon list first before getting each individual details
+/// Clears the state's search result list for refreshing when searching
 class InitPokemonListPageAction extends LoadingAction {
   InitPokemonListPageAction() : super(actionKey: waitKey);
 
@@ -15,7 +16,7 @@ class InitPokemonListPageAction extends LoadingAction {
   Future<AppState> reduce() async {
     await dispatchAndWait(GetSimplePokemonListAction());
     await dispatchAndWait(GetPokemonListAction(simplePokemonList: state.simplePokemonList.simplePokemonList));
-    return state;
+    return state.copyWith(searchResultList: List.empty());
   }
 }
 


### PR DESCRIPTION
- add on refresh and on clear text functions in pokemon list page
- clear text controller and set is searching to false when refreshing in pokemon list page
- clear search result list in init pokemon list page action