### PR TITLE
feat: pokemon info page

### DIFF
--- a/lib/extensions/pokemon_ext.dart
+++ b/lib/extensions/pokemon_ext.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/material.dart';
 import 'package:pokedex_flutter_async_redux/apis/model/pokemon.dart';
 import 'package:pokedex_flutter_async_redux/extensions/pokemon_info_ext.dart';
 import 'package:pokedex_flutter_async_redux/extensions/pokemon_ability_ext.dart';
@@ -8,6 +9,7 @@ import 'package:pokedex_flutter_async_redux/extensions/pokemon_type_ext.dart';
 import 'package:pokedex_flutter_async_redux/model/dto/pokemon_info_dto.dart';
 import 'package:pokedex_flutter_async_redux/model/dto/pokemon_dto.dart';
 import 'package:pokedex_flutter_async_redux/model/dto/pokemon_sprites_dto.dart';
+import 'package:pokedex_flutter_async_redux/utils/pokemon_color_picker.dart';
 
 extension PokemonExt on Pokemon {
   PokemonDto toDto() => PokemonDto(
@@ -27,4 +29,8 @@ extension PokemonExt on Pokemon {
 
 extension PokemonDtoExt on PokemonDto {
   String get imageUrl => sprites.otherSprites.officialArtwork.imageUrl;
+
+  Color get primaryColor => PokemonColorPicker.getColor(firstTypeName);
+
+  String get firstTypeName => typeList.firstOrNull?.name ?? '';
 }

--- a/lib/feature/pokemon_info/pokemon_info_connector.dart
+++ b/lib/feature/pokemon_info/pokemon_info_connector.dart
@@ -1,0 +1,19 @@
+import 'package:async_redux/async_redux.dart';
+import 'package:flutter/material.dart';
+import 'package:pokedex_flutter_async_redux/feature/pokemon_info/pokemon_info_page.dart';
+import 'package:pokedex_flutter_async_redux/feature/pokemon_info/pokemon_info_vm.dart';
+import 'package:pokedex_flutter_async_redux/state/app_state.dart';
+
+class PokemonInfoConnector extends StatelessWidget {
+  const PokemonInfoConnector({super.key});
+
+  static const route = 'pokemon-info';
+
+  @override
+  Widget build(BuildContext context) {
+    return StoreConnector<AppState, PokemonInfoVm>(
+      vm: PokemonInfoVmFactory.new,
+      builder: (_, vm) => PokemonInfoPage(selectedPokemon: vm.selectedPokemon),
+    );
+  }
+}

--- a/lib/feature/pokemon_info/pokemon_info_page.dart
+++ b/lib/feature/pokemon_info/pokemon_info_page.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+import 'package:pokedex_flutter_async_redux/extensions/pokemon_ext.dart';
+import 'package:pokedex_flutter_async_redux/model/dto/pokemon_dto.dart';
+
+class PokemonInfoPage extends StatelessWidget {
+  const PokemonInfoPage({
+    required this.selectedPokemon,
+    super.key,
+  });
+
+  final PokemonDto selectedPokemon;
+
+  @override
+  Widget build(BuildContext context) {
+    final primaryColor = selectedPokemon.primaryColor;
+    return Scaffold(
+      appBar: AppBar(backgroundColor: primaryColor),
+      backgroundColor: primaryColor,
+    );
+  }
+}

--- a/lib/feature/pokemon_info/pokemon_info_vm.dart
+++ b/lib/feature/pokemon_info/pokemon_info_vm.dart
@@ -1,0 +1,15 @@
+import 'package:async_redux/async_redux.dart';
+import 'package:pokedex_flutter_async_redux/feature/pokemon_info/pokemon_info_connector.dart';
+import 'package:pokedex_flutter_async_redux/model/dto/pokemon_dto.dart';
+import 'package:pokedex_flutter_async_redux/state/app_state.dart';
+
+class PokemonInfoVmFactory extends VmFactory<AppState, PokemonInfoConnector, PokemonInfoVm> {
+  @override
+  PokemonInfoVm fromStore() => PokemonInfoVm(selectedPokemon: state.selectedPokemon ?? const PokemonDto());
+}
+
+class PokemonInfoVm extends Vm {
+  final PokemonDto selectedPokemon;
+
+  PokemonInfoVm({required this.selectedPokemon}) : super(equals: [selectedPokemon]);
+}

--- a/lib/feature/pokemon_list/pokemon_list_connector.dart
+++ b/lib/feature/pokemon_list/pokemon_list_connector.dart
@@ -24,6 +24,7 @@ class PokemonListConnector extends StatelessWidget {
         isGettingMorePokemon: vm.isGettingMorePokemon,
         onRefreshPage: vm.onRefreshPage,
         onSearchPokemon: vm.onSearchPokemon,
+        onSelectPokemon: vm.onSelectPokemon,
       ),
     );
   }

--- a/lib/feature/pokemon_list/pokemon_list_vm.dart
+++ b/lib/feature/pokemon_list/pokemon_list_vm.dart
@@ -2,6 +2,7 @@ import 'package:async_redux/async_redux.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:pokedex_flutter_async_redux/feature/pokemon_list/pokemon_list_connector.dart';
+import 'package:pokedex_flutter_async_redux/model/dto/pokemon_dto.dart';
 import 'package:pokedex_flutter_async_redux/model/union_page_state.dart';
 import 'package:pokedex_flutter_async_redux/state/action/actions.dart';
 import 'package:pokedex_flutter_async_redux/state/action/pokemon_actions.dart';
@@ -20,6 +21,7 @@ class PokemonListVmFactory extends VmFactory<AppState, PokemonListConnector, Pok
         isGettingMorePokemon: state.wait.isWaiting(GetMorePokemonAction.waitKey),
         onRefreshPage: _onRefreshPage,
         onSearchPokemon: _onSearchPokemon,
+        onSelectPokemon: _onSelectPokemon,
       );
 
   void _onSetTheme(ThemeMode themeMode) => dispatch(SetThemeAction(themeMode));
@@ -41,17 +43,20 @@ class PokemonListVmFactory extends VmFactory<AppState, PokemonListConnector, Pok
   Future<void> _onRefreshPage() async => dispatch(InitPokemonListPageAction());
 
   void _onSearchPokemon(String searchText) => dispatch(SearchPokemonAction(searchText: searchText));
+
+  void _onSelectPokemon(PokemonDto selectedPokemon) => dispatch(SelectPokemonAction(selectedPokemon: selectedPokemon));
 }
 
 class PokemonListVm extends Vm {
   final ThemeMode savedThemeMode;
   final ValueChanged<ThemeMode> onSetTheme;
+  final ValueChanged<String> onSearchPokemon;
+  final ValueChanged<PokemonDto> onSelectPokemon;
   final UnionPageState<PokemonList> unionPageState;
   final UnionPageState<PokemonList> unionSearchPageState;
   final VoidCallback onGetMorePokemon;
   final bool isGettingMorePokemon;
   final AsyncCallback onRefreshPage;
-  final ValueChanged<String> onSearchPokemon;
 
   PokemonListVm({
     required this.savedThemeMode,
@@ -62,6 +67,7 @@ class PokemonListVm extends Vm {
     required this.isGettingMorePokemon,
     required this.onRefreshPage,
     required this.onSearchPokemon,
+    required this.onSelectPokemon,
   }) : super(
           equals: [
             savedThemeMode,

--- a/lib/feature/pokemon_list/widgets/pokemon_card.dart
+++ b/lib/feature/pokemon_list/widgets/pokemon_card.dart
@@ -7,7 +7,6 @@ import 'package:pokedex_flutter_async_redux/feature/pokemon_list/widgets/pokemon
 import 'package:pokedex_flutter_async_redux/model/dto/pokemon_dto.dart';
 import 'package:pokedex_flutter_async_redux/utils/const.dart';
 import 'package:pokedex_flutter_async_redux/utils/extension.dart';
-import 'package:pokedex_flutter_async_redux/utils/pokemon_color_picker.dart';
 
 class PokemonCard extends StatelessWidget {
   const PokemonCard({
@@ -22,12 +21,10 @@ class PokemonCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final typeList = pokemon.typeList;
-    final firstTypeName = typeList.firstOrNull?.name ?? '';
-
     return GestureDetector(
       onTap: onTap,
       child: Card(
-        color: PokemonColorPicker.getColor(firstTypeName),
+        color: pokemon.primaryColor,
         child: Stack(
           children: [
             Padding(
@@ -45,7 +42,7 @@ class PokemonCard extends StatelessWidget {
                   Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      PokemonTypeName(name: firstTypeName),
+                      PokemonTypeName(name: pokemon.firstTypeName),
                       if (typeList.length > 1) PokemonTypeName(name: typeList.second.name),
                     ],
                   )

--- a/lib/state/action/pokemon_actions.dart
+++ b/lib/state/action/pokemon_actions.dart
@@ -1,5 +1,6 @@
 import 'package:async_redux/async_redux.dart';
 import 'package:pokedex_flutter_async_redux/apis/api_service.dart';
+import 'package:pokedex_flutter_async_redux/model/dto/pokemon_dto.dart';
 import 'package:pokedex_flutter_async_redux/model/dto/simple_pokemon_dto.dart';
 import 'package:pokedex_flutter_async_redux/state/action/actions.dart';
 import 'package:pokedex_flutter_async_redux/state/app_state.dart';
@@ -92,4 +93,14 @@ class SearchPokemonAction extends LoadingAction {
 
     return state.copyWith(searchResultList: searchResultList);
   }
+}
+
+/// Selects the provided [selectedPokemon] to be viewed on the pokemon info page
+class SelectPokemonAction extends ReduxAction<AppState> {
+  SelectPokemonAction({required this.selectedPokemon});
+
+  final PokemonDto selectedPokemon;
+
+  @override
+  AppState reduce() => state.copyWith(selectedPokemon: selectedPokemon);
 }

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -15,5 +15,6 @@ class AppState with _$AppState {
     @Default(SimplePokemonListDto()) SimplePokemonListDto simplePokemonList,
     @Default(<PokemonDto>[]) PokemonList pokemonList,
     @Default(<PokemonDto>[]) PokemonList searchResultList,
+    @Default(null) PokemonDto? selectedPokemon,
   }) = _AppState;
 }

--- a/lib/utils/router.dart
+++ b/lib/utils/router.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:pokedex_flutter_async_redux/feature/pokemon_info/pokemon_info_connector.dart';
 import 'package:pokedex_flutter_async_redux/feature/pokemon_list/pokemon_list_connector.dart';
 
 final navigatorKey = GlobalKey<NavigatorState>();
@@ -10,6 +11,13 @@ final router = GoRouter(
     GoRoute(
       path: PokemonListConnector.route,
       builder: (_, __) => const PokemonListConnector(),
+      routes: [
+        GoRoute(
+          path: PokemonInfoConnector.route,
+          name: PokemonInfoConnector.route,
+          builder: (_, __) => const PokemonInfoConnector(),
+        ),
+      ],
     ),
   ],
   initialLocation: PokemonListConnector.route,


### PR DESCRIPTION
- add selected pokemon property in app state
- crerete action for selecting pokemon
- add primary color and first type name getters in pokemon dto extension and use in pokemon card
- add on select pokemon parameter in pokemon list page and vm
- remove unnecessary build context parameter in functions in pokemon list page
- add on tap pokemon card function in pokemon list page
- create initial pokemon info page, connector, and vm
- add pokemon info connector route in router