### PR TITLE
feat: pokemon info header

### DIFF
--- a/lib/extensions/pokemon_ext.dart
+++ b/lib/extensions/pokemon_ext.dart
@@ -1,3 +1,4 @@
+import 'package:dartx/dartx.dart';
 import 'package:flutter/material.dart';
 import 'package:pokedex_flutter_async_redux/apis/model/pokemon.dart';
 import 'package:pokedex_flutter_async_redux/extensions/pokemon_info_ext.dart';
@@ -28,9 +29,9 @@ extension PokemonExt on Pokemon {
 }
 
 extension PokemonDtoExt on PokemonDto {
-  String get imageUrl => sprites.otherSprites.officialArtwork.imageUrl;
+  Color get primaryColor => PokemonColorPicker.getColor(primaryTypeName);
 
-  Color get primaryColor => PokemonColorPicker.getColor(firstTypeName);
+  String get primaryTypeName => typeList.firstOrNull?.name ?? '';
 
-  String get firstTypeName => typeList.firstOrNull?.name ?? '';
+  String get capitalizedNamed => name.capitalize();
 }

--- a/lib/feature/pokemon_info/pokemon_info_connector.dart
+++ b/lib/feature/pokemon_info/pokemon_info_connector.dart
@@ -2,6 +2,7 @@ import 'package:async_redux/async_redux.dart';
 import 'package:flutter/material.dart';
 import 'package:pokedex_flutter_async_redux/feature/pokemon_info/pokemon_info_page.dart';
 import 'package:pokedex_flutter_async_redux/feature/pokemon_info/pokemon_info_vm.dart';
+import 'package:pokedex_flutter_async_redux/state/action/pokemon_actions.dart';
 import 'package:pokedex_flutter_async_redux/state/app_state.dart';
 
 class PokemonInfoConnector extends StatelessWidget {
@@ -13,6 +14,7 @@ class PokemonInfoConnector extends StatelessWidget {
   Widget build(BuildContext context) {
     return StoreConnector<AppState, PokemonInfoVm>(
       vm: PokemonInfoVmFactory.new,
+      onDispose: (store) => store.dispatch(SelectPokemonAction(selectedPokemon: null)),
       builder: (_, vm) => PokemonInfoPage(selectedPokemon: vm.selectedPokemon),
     );
   }

--- a/lib/feature/pokemon_info/pokemon_info_page.dart
+++ b/lib/feature/pokemon_info/pokemon_info_page.dart
@@ -1,6 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:pokedex_flutter_async_redux/extensions/pokemon_ext.dart';
 import 'package:pokedex_flutter_async_redux/model/dto/pokemon_dto.dart';
+import 'package:pokedex_flutter_async_redux/utils/const.dart';
+import 'package:pokedex_flutter_async_redux/utils/extension.dart';
+import 'package:pokedex_flutter_async_redux/widgets/pokemon_image.dart';
+import 'package:pokedex_flutter_async_redux/widgets/pokemon_type_list.dart';
 
 class PokemonInfoPage extends StatelessWidget {
   const PokemonInfoPage({
@@ -13,9 +17,42 @@ class PokemonInfoPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final primaryColor = selectedPokemon.primaryColor;
+    final textTheme = context.textTheme;
+
     return Scaffold(
       appBar: AppBar(backgroundColor: primaryColor),
       backgroundColor: primaryColor,
+      body: Column(
+        children: [
+          Padding(
+            padding: infoPageHeaderPadding,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  selectedPokemon.capitalizedNamed,
+                  style: textTheme.displayLarge,
+                ),
+                Align(
+                  alignment: Alignment.centerRight,
+                  child: Text(
+                    '#${selectedPokemon.id.toString().padLeft(idNumberPadWidth, '0')}',
+                    style: textTheme.displaySmall,
+                  ),
+                ),
+                PokemonTypeList(
+                  pokemon: selectedPokemon,
+                  isDecorationShown: true,
+                ),
+                PokemonImage(
+                  pokemon: selectedPokemon,
+                  size: infoPageImageSize,
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/lib/feature/pokemon_list/widgets/pokemon_card.dart
+++ b/lib/feature/pokemon_list/widgets/pokemon_card.dart
@@ -1,12 +1,10 @@
-import 'package:cached_network_image/cached_network_image.dart';
-import 'package:dartx/dartx.dart';
 import 'package:flutter/material.dart';
 import 'package:pokedex_flutter_async_redux/extensions/pokemon_ext.dart';
-import 'package:pokedex_flutter_async_redux/extensions/pokemon_type_ext.dart';
-import 'package:pokedex_flutter_async_redux/feature/pokemon_list/widgets/pokemon_type_name.dart';
 import 'package:pokedex_flutter_async_redux/model/dto/pokemon_dto.dart';
 import 'package:pokedex_flutter_async_redux/utils/const.dart';
 import 'package:pokedex_flutter_async_redux/utils/extension.dart';
+import 'package:pokedex_flutter_async_redux/widgets/pokemon_image.dart';
+import 'package:pokedex_flutter_async_redux/widgets/pokemon_type_list.dart';
 
 class PokemonCard extends StatelessWidget {
   const PokemonCard({
@@ -20,7 +18,6 @@ class PokemonCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final typeList = pokemon.typeList;
     return GestureDetector(
       onTap: onTap,
       child: Card(
@@ -35,32 +32,20 @@ class PokemonCard extends StatelessWidget {
                   Padding(
                     padding: pokemonNamePadding,
                     child: Text(
-                      pokemon.name.capitalize(),
+                      pokemon.capitalizedNamed,
                       style: context.textTheme.headlineMedium,
                     ),
                   ),
-                  Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      PokemonTypeName(name: pokemon.firstTypeName),
-                      if (typeList.length > 1) PokemonTypeName(name: typeList.second.name),
-                    ],
-                  )
+                  PokemonTypeList(pokemon: pokemon),
                 ],
               ),
             ),
             Positioned(
               bottom: 0.0,
               right: 0.0,
-              child: Hero(
-                tag: pokemon.id,
-                child: Container(
-                  width: pokemonCardSize,
-                  height: pokemonCardSize,
-                  decoration: BoxDecoration(
-                    image: DecorationImage(image: CachedNetworkImageProvider(pokemon.imageUrl)),
-                  ),
-                ),
+              child: PokemonImage(
+                pokemon: pokemon,
+                size: pokemonCardSize,
               ),
             ),
           ],

--- a/lib/feature/pokemon_list/widgets/pokemon_type_name.dart
+++ b/lib/feature/pokemon_list/widgets/pokemon_type_name.dart
@@ -6,16 +6,33 @@ import 'package:pokedex_flutter_async_redux/utils/extension.dart';
 class PokemonTypeName extends StatelessWidget {
   const PokemonTypeName({
     required this.name,
+    this.primaryColor,
     super.key,
   });
 
   final String name;
+  final Color? primaryColor;
+
+  Color _typeDecorationColor() {
+    final color = primaryColor ?? Colors.transparent;
+    final hsl = HSLColor.fromColor(color);
+    final hslLight = hsl.withLightness(hsl.lightness + lightnessAddition);
+
+    return hslLight.toColor();
+  }
 
   @override
   Widget build(BuildContext context) {
     return Container(
       padding: pokemonTypeNamePadding,
       margin: pokemonTypeNameMargin,
+      decoration: primaryColor == null
+          ? null
+          : BoxDecoration(
+              color: _typeDecorationColor(),
+              border: Border.all(color: Colors.transparent),
+              borderRadius: BorderRadius.circular(typeNameRadius),
+            ),
       child: Text(
         name.capitalize(),
         style: context.textTheme.headlineMedium,

--- a/lib/state/action/pokemon_actions.dart
+++ b/lib/state/action/pokemon_actions.dart
@@ -99,7 +99,7 @@ class SearchPokemonAction extends LoadingAction {
 class SelectPokemonAction extends ReduxAction<AppState> {
   SelectPokemonAction({required this.selectedPokemon});
 
-  final PokemonDto selectedPokemon;
+  final PokemonDto? selectedPokemon;
 
   @override
   AppState reduce() => state.copyWith(selectedPokemon: selectedPokemon);

--- a/lib/utils/const.dart
+++ b/lib/utils/const.dart
@@ -1,13 +1,23 @@
 import 'package:flutter/material.dart';
 
+const morePokemonCount = 20;
+
+// Pokemon List Page
 const pokemonTypeNamePadding = EdgeInsets.symmetric(vertical: 4.0, horizontal: 12.0);
-const pokemonTypeNameMargin = EdgeInsets.only(bottom: 4.0);
+const pokemonTypeNameMargin = EdgeInsets.only(bottom: 4.0, right: 8.0);
 const pokemonCardSize = 80.0;
 const pokemonCardPadding = EdgeInsets.all(8.0);
 const pokemonNamePadding = EdgeInsets.symmetric(vertical: 8.0);
 const pokemonListPageFooterHeight = 100.0;
 const pokemonGridDelegate = SliverGridDelegateWithMaxCrossAxisExtent(maxCrossAxisExtent: 250, childAspectRatio: 3 / 2);
 const pokemonListPagePadding = EdgeInsets.symmetric(horizontal: 12.0);
-const morePokemonCount = 20;
 const progressIndicatorFooterPadding = EdgeInsets.all(12.0);
 const debouncerDelayInMilliseconds = 300;
+
+// Pokemon Info Page
+
+const infoPageHeaderPadding = EdgeInsets.symmetric(vertical: 8.0, horizontal: 16.0);
+const idNumberPadWidth = 3;
+const infoPageImageSize = 200.0;
+const lightnessAddition = 0.1;
+const typeNameRadius = 20.0;

--- a/lib/widgets/pokemon_image.dart
+++ b/lib/widgets/pokemon_image.dart
@@ -1,0 +1,32 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+import 'package:pokedex_flutter_async_redux/model/dto/pokemon_dto.dart';
+
+class PokemonImage extends StatelessWidget {
+  const PokemonImage({
+    required this.pokemon,
+    required this.size,
+    super.key,
+  });
+
+  final PokemonDto pokemon;
+  final double size;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Hero(
+        tag: pokemon.id,
+        child: Container(
+          width: size,
+          height: size,
+          decoration: BoxDecoration(
+            image: DecorationImage(
+              image: CachedNetworkImageProvider(pokemon.sprites.otherSprites.officialArtwork.imageUrl),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/pokemon_type_list.dart
+++ b/lib/widgets/pokemon_type_list.dart
@@ -1,0 +1,43 @@
+import 'package:dartx/dartx.dart';
+import 'package:flutter/material.dart';
+import 'package:pokedex_flutter_async_redux/extensions/pokemon_ext.dart';
+import 'package:pokedex_flutter_async_redux/extensions/pokemon_type_ext.dart';
+import 'package:pokedex_flutter_async_redux/feature/pokemon_list/widgets/pokemon_type_name.dart';
+import 'package:pokedex_flutter_async_redux/model/dto/pokemon_dto.dart';
+import 'package:pokedex_flutter_async_redux/utils/pokemon_color_picker.dart';
+
+class PokemonTypeList extends StatelessWidget {
+  const PokemonTypeList({
+    required this.pokemon,
+    this.isDecorationShown = false,
+    super.key,
+  });
+
+  final PokemonDto pokemon;
+  final bool isDecorationShown;
+
+  @override
+  Widget build(BuildContext context) {
+    final primaryTypeName = pokemon.primaryTypeName;
+    final primaryColor = isDecorationShown ? PokemonColorPicker.getColor(primaryTypeName) : null;
+    final typeList = pokemon.typeList;
+    final children = [
+      PokemonTypeName(
+        name: primaryTypeName,
+        primaryColor: primaryColor,
+      ),
+      if (typeList.length > 1)
+        PokemonTypeName(
+          name: typeList.second.name,
+          primaryColor: primaryColor,
+        ),
+    ];
+
+    return isDecorationShown
+        ? Row(children: children)
+        : Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: children,
+          );
+  }
+}


### PR DESCRIPTION
- create pokemon image and type list reusable widgets
- add consts
- set selected pokemon parameter in select pokemon action to nullable
- remove image url  getter in pokemon dto extension
- add capitalize named getter in pokemon dto extension
- renme first type name getter to primary type name in pokemon dto extension
- use select pokemon action when disposing pokemon info connector
- add primary color parameter in pokemon type name
- add type decoration color function in pokemon type name
- add image, name, and types in pokemon info page