### PR TITLE
feat: pokemon info modal

### DIFF
--- a/lib/feature/pokemon_info/pokemon_info_page.dart
+++ b/lib/feature/pokemon_info/pokemon_info_page.dart
@@ -3,6 +3,8 @@ import 'package:pokedex_flutter_async_redux/extensions/pokemon_ext.dart';
 import 'package:pokedex_flutter_async_redux/model/dto/pokemon_dto.dart';
 import 'package:pokedex_flutter_async_redux/utils/const.dart';
 import 'package:pokedex_flutter_async_redux/utils/extension.dart';
+import 'package:pokedex_flutter_async_redux/utils/pokemon_color_picker.dart';
+import 'package:pokedex_flutter_async_redux/utils/strings.dart';
 import 'package:pokedex_flutter_async_redux/widgets/pokemon_image.dart';
 import 'package:pokedex_flutter_async_redux/widgets/pokemon_type_list.dart';
 
@@ -17,7 +19,9 @@ class PokemonInfoPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final primaryColor = selectedPokemon.primaryColor;
+    final typeDecorationColor = PokemonColorPicker.typeDecorationColor(primaryColor, isDarkened: true);
     final textTheme = context.textTheme;
+    final themeData = context.themeData;
 
     return Scaffold(
       appBar: AppBar(backgroundColor: primaryColor),
@@ -49,6 +53,37 @@ class PokemonInfoPage extends StatelessWidget {
                   size: infoPageImageSize,
                 ),
               ],
+            ),
+          ),
+          Expanded(
+            child: Container(
+              padding: infoPageModalPadding,
+              decoration: BoxDecoration(
+                color: themeData.primaryColor,
+                borderRadius: infoPageModalRadius,
+              ),
+              child: DefaultTabController(
+                length: tabLabels.length,
+                child: Column(
+                  children: [
+                    TabBar(
+                      labelColor: typeDecorationColor,
+                      indicatorColor: typeDecorationColor,
+                      unselectedLabelColor: themeData.unselectedWidgetColor,
+                      tabs: tabLabels.map((tabLabel) => Tab(text: tabLabel)).toList(),
+                    ),
+                    const Expanded(
+                      child: TabBarView(
+                        children: [
+                          SizedBox(),
+                          SizedBox(),
+                          SizedBox(),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+              ),
             ),
           ),
         ],

--- a/lib/feature/pokemon_list/widgets/pokemon_type_name.dart
+++ b/lib/feature/pokemon_list/widgets/pokemon_type_name.dart
@@ -2,6 +2,7 @@ import 'package:dartx/dartx.dart';
 import 'package:flutter/material.dart';
 import 'package:pokedex_flutter_async_redux/utils/const.dart';
 import 'package:pokedex_flutter_async_redux/utils/extension.dart';
+import 'package:pokedex_flutter_async_redux/utils/pokemon_color_picker.dart';
 
 class PokemonTypeName extends StatelessWidget {
   const PokemonTypeName({
@@ -13,14 +14,6 @@ class PokemonTypeName extends StatelessWidget {
   final String name;
   final Color? primaryColor;
 
-  Color _typeDecorationColor() {
-    final color = primaryColor ?? Colors.transparent;
-    final hsl = HSLColor.fromColor(color);
-    final hslLight = hsl.withLightness(hsl.lightness + lightnessAddition);
-
-    return hslLight.toColor();
-  }
-
   @override
   Widget build(BuildContext context) {
     return Container(
@@ -29,7 +22,7 @@ class PokemonTypeName extends StatelessWidget {
       decoration: primaryColor == null
           ? null
           : BoxDecoration(
-              color: _typeDecorationColor(),
+              color: PokemonColorPicker.typeDecorationColor(primaryColor ?? Colors.transparent),
               border: Border.all(color: Colors.transparent),
               borderRadius: BorderRadius.circular(typeNameRadius),
             ),

--- a/lib/utils/const.dart
+++ b/lib/utils/const.dart
@@ -15,9 +15,10 @@ const progressIndicatorFooterPadding = EdgeInsets.all(12.0);
 const debouncerDelayInMilliseconds = 300;
 
 // Pokemon Info Page
-
 const infoPageHeaderPadding = EdgeInsets.symmetric(vertical: 8.0, horizontal: 16.0);
 const idNumberPadWidth = 3;
 const infoPageImageSize = 200.0;
-const lightnessAddition = 0.1;
+const colorModifier = 0.1;
 const typeNameRadius = 20.0;
+const infoPageModalPadding = EdgeInsets.symmetric(horizontal: 4.0);
+const infoPageModalRadius = BorderRadius.vertical(top: Radius.circular(20.0));

--- a/lib/utils/extension.dart
+++ b/lib/utils/extension.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
 extension BuildContextExt on BuildContext {
-  TextTheme get textTheme => Theme.of(this).textTheme;
+  TextTheme get textTheme => themeData.textTheme;
+
+  ThemeData get themeData => Theme.of(this);
 }

--- a/lib/utils/pokemon_color_picker.dart
+++ b/lib/utils/pokemon_color_picker.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:pokedex_flutter_async_redux/utils/const.dart';
 
 class PokemonColorPicker {
   static Color getColor(String type) => switch (type) {
@@ -22,4 +23,11 @@ class PokemonColorPicker {
         'fairy' => const Color(0xffD685AD),
         _ => const Color(0xffffffff),
       };
+
+  static Color typeDecorationColor(Color color, {bool isDarkened = false}) {
+    final hsl = HSLColor.fromColor(color);
+    final hslLight = hsl.withLightness(hsl.lightness + (isDarkened ? -colorModifier : colorModifier));
+
+    return hslLight.toColor();
+  }
 }

--- a/lib/utils/strings.dart
+++ b/lib/utils/strings.dart
@@ -1,6 +1,11 @@
-const appTitle = 'Pokedex';
-const chooseThemeMenuLabel = 'Choose Theme';
 const themeSharedPrefsKey = 'theme';
 const baseUrl = 'https://pokeapi.co/api/v2';
+
+// Pokemon List Page
+const appTitle = 'Pokedex';
+const chooseThemeMenuLabel = 'Choose Theme';
 const emptyPokemonLabel = 'No Pokemon Found';
 const searchFieldHintText = 'Search Pokemon';
+
+// Pokemon Info Page
+const tabLabels = ['About', 'Evolution', 'Moves'];


### PR DESCRIPTION
- add initial tab bar and view n pokemon info page
- add theme data extensso in build context extension
- add type decoration color method in pokemon color picker
- remove type decoration color function in pokemon type name
- add consts and strings