### PR TITLE
feat: pokemon evolutions

### DIFF
--- a/lib/apis/model/evolves_to.dart
+++ b/lib/apis/model/evolves_to.dart
@@ -1,0 +1,16 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:pokedex_flutter_async_redux/apis/model/pokemon_info.dart';
+import 'package:pokedex_flutter_async_redux/utils/typedef.dart';
+
+part 'evolves_to.freezed.dart';
+part 'evolves_to.g.dart';
+
+@freezed
+class EvolvesTo with _$EvolvesTo {
+  const factory EvolvesTo({
+    @JsonKey(name: 'species') PokemonInfo? speciesInfo,
+    @JsonKey(name: 'evolves_to') List<EvolvesTo>? evolutions,
+  }) = _EvolvesTo;
+
+  factory EvolvesTo.fromJson(Json json) => _$EvolvesToFromJson(json);
+}

--- a/lib/apis/model/pokemon_evolution_chain.dart
+++ b/lib/apis/model/pokemon_evolution_chain.dart
@@ -1,0 +1,15 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:pokedex_flutter_async_redux/apis/model/evolves_to.dart';
+import 'package:pokedex_flutter_async_redux/utils/typedef.dart';
+
+part 'pokemon_evolution_chain.freezed.dart';
+part 'pokemon_evolution_chain.g.dart';
+
+@freezed
+class PokemonEvolutionChain with _$PokemonEvolutionChain {
+  const factory PokemonEvolutionChain({
+    @JsonKey(name: 'chain') EvolvesTo? chain,
+  }) = _PokemonEvolutionChain;
+
+  factory PokemonEvolutionChain.fromJson(Json json) => _$PokemonEvolutionChainFromJson(json);
+}

--- a/lib/apis/pokemon_api.dart
+++ b/lib/apis/pokemon_api.dart
@@ -72,7 +72,6 @@ class PokemonApi {
   }
 
   Future<PokemonList> getEvolutionList({required PokemonEvolutionChainDto evolutionChain}) async {
-    final evolutionList = <PokemonDto>[];
     final futures = <Future<Response<Json>>>[];
     final dio = apiClient.dio;
     final baseUrl = '${apiClient.baseUrl}/pokemon';
@@ -91,8 +90,9 @@ class PokemonApi {
     }
 
     final responses = await Future.wait(futures);
-
+    final evolutionList = <PokemonDto>[];
     final pokemon = Pokemon.fromJson(responses.first.data!);
+
     evolutionList.add(pokemon.toDto());
 
     for (final stage2Evolution in responses.sublist(1)) {

--- a/lib/apis/pokemon_api.dart
+++ b/lib/apis/pokemon_api.dart
@@ -1,11 +1,16 @@
 import 'package:dio/dio.dart';
 import 'package:pokedex_flutter_async_redux/apis/api_client.dart';
 import 'package:pokedex_flutter_async_redux/apis/model/pokemon.dart';
+import 'package:pokedex_flutter_async_redux/apis/model/pokemon_evolution_chain.dart';
 import 'package:pokedex_flutter_async_redux/apis/model/pokemon_species.dart';
 import 'package:pokedex_flutter_async_redux/apis/model/simple_pokemon_list.dart';
+import 'package:pokedex_flutter_async_redux/extensions/evolves_to_ext.dart';
+import 'package:pokedex_flutter_async_redux/extensions/pokemon_evolution_chain_ext.dart';
 import 'package:pokedex_flutter_async_redux/extensions/pokemon_ext.dart';
 import 'package:pokedex_flutter_async_redux/extensions/pokemon_species_ext.dart';
 import 'package:pokedex_flutter_async_redux/extensions/simple_pokemon_list_ext.dart';
+import 'package:pokedex_flutter_async_redux/model/dto/pokemon_dto.dart';
+import 'package:pokedex_flutter_async_redux/model/dto/pokemon_evolution_chain_dto.dart';
 import 'package:pokedex_flutter_async_redux/model/dto/pokemon_species_dto.dart';
 import 'package:pokedex_flutter_async_redux/model/dto/simple_pokemon_dto.dart';
 import 'package:pokedex_flutter_async_redux/model/dto/simple_pokemon_list_dto.dart';
@@ -24,7 +29,7 @@ class PokemonApi {
     return simplePokemonList.toDto();
   }
 
-  Future<PokemonList> getPokemonList(List<SimplePokemonDto> simplePokemonList) async {
+  Future<PokemonList> getPokemonList({required List<SimplePokemonDto> simplePokemonList}) async {
     final dio = apiClient.dio;
 
     final futures = simplePokemonList.map((simplePokemon) {
@@ -38,7 +43,7 @@ class PokemonApi {
     return responses.map((response) => Pokemon.fromJson(response.data!).toDto()).toList();
   }
 
-  Future<PokemonList> searchPokemon(String pokemonName) async {
+  Future<PokemonList> searchPokemon({required String pokemonName}) async {
     final baseUrl = apiClient.baseUrl;
     final fetchUrl = '$baseUrl/pokemon/$pokemonName';
 
@@ -52,10 +57,54 @@ class PokemonApi {
     }
   }
 
-  Future<PokemonSpeciesDto> getPokemonSpecies(String speciesUrl) async {
+  Future<PokemonSpeciesDto> getSpecies({required String speciesUrl}) async {
     final response = await apiClient.dio.get<Json>(speciesUrl);
     final pokemonSpecies = PokemonSpecies.fromJson(response.data!);
 
     return pokemonSpecies.toDto();
+  }
+
+  Future<PokemonEvolutionChainDto> getEvolutionChain({required String evolutionChainUrl}) async {
+    final response = await apiClient.dio.get<Json>(evolutionChainUrl);
+    final evolutionChain = PokemonEvolutionChain.fromJson(response.data!);
+
+    return evolutionChain.toDto();
+  }
+
+  Future<PokemonList> getEvolutionList({required PokemonEvolutionChainDto evolutionChain}) async {
+    final evolutionList = <PokemonDto>[];
+    final futures = <Future<Response<Json>>>[];
+    final dio = apiClient.dio;
+    final baseUrl = '${apiClient.baseUrl}/pokemon';
+
+    String fetchUrl = '$baseUrl/${evolutionChain.chain.speciesName}';
+    futures.add(dio.get(fetchUrl));
+
+    for (final stage2Evolution in evolutionChain.stage2Evolutions) {
+      fetchUrl = '$baseUrl/${stage2Evolution.speciesName}';
+      futures.add(dio.get(fetchUrl));
+    }
+
+    for (final stage3Evolution in evolutionChain.stage3Evolutions) {
+      fetchUrl = '$baseUrl/${stage3Evolution.speciesName}';
+      futures.add(dio.get(fetchUrl));
+    }
+
+    final responses = await Future.wait(futures);
+
+    final pokemon = Pokemon.fromJson(responses.first.data!);
+    evolutionList.add(pokemon.toDto());
+
+    for (final stage2Evolution in responses.sublist(1)) {
+      final pokemon = Pokemon.fromJson(stage2Evolution.data!);
+      evolutionList.add(pokemon.toDto());
+    }
+
+    for (final stage3Evolution in responses.sublist(evolutionList.length)) {
+      final pokemon = Pokemon.fromJson(stage3Evolution.data!);
+      evolutionList.add(pokemon.toDto());
+    }
+
+    return evolutionList;
   }
 }

--- a/lib/extensions/evolves_to_ext.dart
+++ b/lib/extensions/evolves_to_ext.dart
@@ -1,0 +1,15 @@
+import 'package:pokedex_flutter_async_redux/apis/model/evolves_to.dart';
+import 'package:pokedex_flutter_async_redux/extensions/pokemon_info_ext.dart';
+import 'package:pokedex_flutter_async_redux/model/dto/evolves_to_dto.dart';
+import 'package:pokedex_flutter_async_redux/model/dto/pokemon_info_dto.dart';
+
+extension EvolvesToExt on EvolvesTo {
+  EvolvesToDto toDto() => EvolvesToDto(
+        speciesInfo: speciesInfo?.toDto() ?? const PokemonInfoDto(),
+        evolutions: [...?evolutions?.map((evolution) => evolution.toDto())],
+      );
+}
+
+extension EvolvesToDtoExt on EvolvesToDto {
+  String get speciesName => speciesInfo.name;
+}

--- a/lib/extensions/pokemon_evolution_chain_ext.dart
+++ b/lib/extensions/pokemon_evolution_chain_ext.dart
@@ -1,0 +1,25 @@
+import 'package:pokedex_flutter_async_redux/apis/model/pokemon_evolution_chain.dart';
+import 'package:pokedex_flutter_async_redux/extensions/evolves_to_ext.dart';
+import 'package:pokedex_flutter_async_redux/model/dto/evolves_to_dto.dart';
+import 'package:pokedex_flutter_async_redux/model/dto/pokemon_evolution_chain_dto.dart';
+import 'package:pokedex_flutter_async_redux/utils/typedef.dart';
+
+extension PokemonEvolutionChainExt on PokemonEvolutionChain {
+  PokemonEvolutionChainDto toDto() => PokemonEvolutionChainDto(chain: chain?.toDto() ?? const EvolvesToDto());
+}
+
+extension PokemonEvolutionChainDtoExt on PokemonEvolutionChainDto {
+  EvolvesToList get stage2Evolutions => chain.evolutions;
+
+  EvolvesToList get stage3Evolutions {
+    final stage3Evolutions = <EvolvesToDto>[];
+
+    for (final stage2Evolution in stage2Evolutions) {
+      for (final stage3Evolution in stage2Evolution.evolutions) {
+        stage3Evolutions.add(stage3Evolution);
+      }
+    }
+
+    return stage3Evolutions;
+  }
+}

--- a/lib/feature/pokemon_info/pokemon_info_connector.dart
+++ b/lib/feature/pokemon_info/pokemon_info_connector.dart
@@ -14,8 +14,8 @@ class PokemonInfoConnector extends StatelessWidget {
   Widget build(BuildContext context) {
     return StoreConnector<AppState, PokemonInfoVm>(
       vm: PokemonInfoVmFactory.new,
-      onInit: (store) => store.dispatch(GetPokemonSpeciesAction()),
-      onDispose: (store) => store.dispatch(SelectPokemonAction(selectedPokemon: null)),
+      onInit: (store) => store.dispatch(InitPokemonInfoPageAction()),
+      onDispose: (store) => store.dispatch(ClearPokemonInfoPageAction()),
       builder: (_, vm) => PokemonInfoPage(
         selectedPokemon: vm.selectedPokemon,
         isLoading: vm.isLoading,

--- a/lib/feature/pokemon_info/pokemon_info_vm.dart
+++ b/lib/feature/pokemon_info/pokemon_info_vm.dart
@@ -9,7 +9,7 @@ class PokemonInfoVmFactory extends VmFactory<AppState, PokemonInfoConnector, Pok
   @override
   PokemonInfoVm fromStore() => PokemonInfoVm(
         selectedPokemon: state.selectedPokemon ?? const PokemonDto(),
-        isLoading: state.wait.isWaiting(GetPokemonSpeciesAction.waitKey),
+        isLoading: state.wait.isWaiting(InitPokemonInfoPageAction.waitKey),
         pokemonSpecies: state.pokemonSpecies ?? const PokemonSpeciesDto(),
       );
 }

--- a/lib/model/dto/evolves_to_dto.dart
+++ b/lib/model/dto/evolves_to_dto.dart
@@ -1,0 +1,13 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:pokedex_flutter_async_redux/model/dto/pokemon_info_dto.dart';
+import 'package:pokedex_flutter_async_redux/utils/typedef.dart';
+
+part 'evolves_to_dto.freezed.dart';
+
+@freezed
+class EvolvesToDto with _$EvolvesToDto {
+  const factory EvolvesToDto({
+    @Default(PokemonInfoDto()) PokemonInfoDto speciesInfo,
+    @Default(<EvolvesToDto>[]) EvolvesToList evolutions,
+  }) = _EvolvesToDto;
+}

--- a/lib/model/dto/pokemon_evolution_chain_dto.dart
+++ b/lib/model/dto/pokemon_evolution_chain_dto.dart
@@ -1,0 +1,11 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:pokedex_flutter_async_redux/model/dto/evolves_to_dto.dart';
+
+part 'pokemon_evolution_chain_dto.freezed.dart';
+
+@freezed
+class PokemonEvolutionChainDto with _$PokemonEvolutionChainDto {
+  const factory PokemonEvolutionChainDto({
+    @Default(EvolvesToDto()) EvolvesToDto chain,
+  }) = _PokemonEvolutionChainDto;
+}

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -2,6 +2,7 @@ import 'package:async_redux/async_redux.dart';
 import 'package:flutter/material.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:pokedex_flutter_async_redux/model/dto/pokemon_dto.dart';
+import 'package:pokedex_flutter_async_redux/model/dto/pokemon_evolution_chain_dto.dart';
 import 'package:pokedex_flutter_async_redux/model/dto/pokemon_species_dto.dart';
 import 'package:pokedex_flutter_async_redux/model/dto/simple_pokemon_list_dto.dart';
 import 'package:pokedex_flutter_async_redux/utils/typedef.dart';
@@ -18,5 +19,7 @@ class AppState with _$AppState {
     @Default(<PokemonDto>[]) PokemonList searchResultList,
     @Default(null) PokemonDto? selectedPokemon,
     @Default(null) PokemonSpeciesDto? pokemonSpecies,
+    @Default(null) PokemonEvolutionChainDto? pokemonEvolutionChain,
+    @Default(<PokemonDto>[]) PokemonList pokemonEvolutionList,
   }) = _AppState;
 }

--- a/lib/utils/typedef.dart
+++ b/lib/utils/typedef.dart
@@ -1,5 +1,8 @@
+import 'package:pokedex_flutter_async_redux/model/dto/evolves_to_dto.dart';
 import 'package:pokedex_flutter_async_redux/model/dto/pokemon_dto.dart';
 
 typedef Json = Map<String, dynamic>;
+
+typedef EvolvesToList = List<EvolvesToDto>;
 
 typedef PokemonList = List<PokemonDto>;


### PR DESCRIPTION
- create api and dto models for evolves to and pokemon evolution chain
- add typedef for evolves to list
- add pokemon evolution chain and list properties in app state
- change all parameters in pokemon api to named
- add get evolution chain and list methods in pokemon api
- create action for init and clearing pokemon info page, and getting pokemon evolution chain and list
- change get pokemon species action to just redux action
- update on init and dispose in pokemon info connector
- update is loading in pokemon info vm
- create extension for evolves to and pokemon evolution chain with to dto methods