### PR TITLE
chore: dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,12 +4,19 @@ updates:
   - package-ecosystem: "pub"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
 
   - package-ecosystem: "gradle"
-    directory: "/"
+    directory: "/android"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+
+  - package-ecosystem: "bundler"
+    directories:
+      - "/android"
+      - "/ios"
+    schedule:
+      interval: "monthly"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
- switch interval of pub and gradle ecosystem to monthly
- fix directory of gradle ecosystem to android
- add bundler ecosystem