### PR TITLE
chore: followed by

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -29,10 +29,9 @@ void main() async {
     StoreProvider<AppState>(
       store: store,
       child: DevicePreview(
-        tools: [
-          ...DevicePreview.defaultTools,
+        tools: DevicePreview.defaultTools.followedBy([
           DevicePreviewScreenshot(onScreenshot: screenshotAsFiles(Directory(downloadDirectory))),
-        ],
+        ]).toList(),
         builder: (_) => const PokedexAppConnector(),
       ),
     ),

--- a/lib/state/action/pokemon_actions.dart
+++ b/lib/state/action/pokemon_actions.dart
@@ -50,7 +50,7 @@ class GetPokemonListAction extends ReduxAction<AppState> {
   @override
   Future<AppState> reduce() async {
     final receivedPokemonList = await ApiService.pokemonApi.getPokemonList(simplePokemonList: simplePokemonList);
-    final updatedPokemonList = [...state.pokemonList, ...receivedPokemonList];
+    final updatedPokemonList = state.pokemonList.followedBy(receivedPokemonList).toList();
 
     return state.copyWith(pokemonList: updatedPokemonList);
   }


### PR DESCRIPTION
- use followed by instead of spread operator in get pokemon list action
- use followed by instead of spread operatior in device preview tools in main